### PR TITLE
19 chore add parallel command to run core demo docs at once

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "sourceType": "module"
   },
   "env": {
+    "browser": true,
     "node": true,
     "es6": true
   }

--- a/core/dist/index.js
+++ b/core/dist/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 // esbuild-scss-modules-plugin:./ReactScriptPlayer.module.scss
 var digest = "e43dd2dcd17a6df0f76a4acecb4fc455d13a542ff476cd474e6b61011f1bfcd7";
 var classes = { "subtitleContainer": "_subtitleContainer_1shar_7", "title": "_title_1shar_19", "lineViewContainer": "_lineViewContainer_1shar_24", "skipButtonContainer": "_skipButtonContainer_1shar_29", "blockViewContainer": "_blockViewContainer_1shar_36", "subtitleItem": "_subtitleItem_1shar_42", "timeButton": "_timeButton_1shar_47", "textView": "_textView_1shar_60", "textEn": "_textEN_1shar_65" };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "core": "yarn workspace react-player-plugin-prompter",
     "demo": "yarn workspace demo",
     "docs": "yarn workspace docs",
+    "dev" : "yarn core dev & yarn demo dev",
     "typecheck": "yarn workspaces foreach --all run typecheck",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
### 📄 Description of the PR

- 기능 설명 :  dev명령어 병렬 실행 가능하게 dev 스크립트 추가.
- Close #19 

### 🔧 What has been changed?

<!-- 이번 PR에서의 변경점 (- 코드 변경, 기능 추가, 버그 수정 등.)-->
- chore : dev명령어 병렬 실행 가능하게 dev 스크립트 추가.
- fix : dev실행할때마다 뜨는 document, browser lint에러 해결

### 📸 Screenshots / GIFs (if applicable)

<!-- 가능하다면 스크린샷이나 GIF를 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/19b2d355-0954-40a7-baae-ce2c9ed327fc)

core는 esbuild, demo는 vite를 사용하고 있어서 build형식이 다르기 때문에 콘솔에 찍히는 모양이 다를 뿐, core는 --watch에 따라, dev는 vite의 hmr(hot module replacement)로 변경된 모듈만 업데이트됩니다. 
### ⚠️ Precaution & Known issues

<!-- 리뷰할 때 고려해야 할 부분, 수정이 필요한 부분, 아직 해결되지 않는 문제, 개선해야 할 사항 -->

### ✅ Checklist

- [ ] UI 브랜치 같이 확인해서 이슈없는지 확인해보기
- [ ] 함수 이름, 변수 이름만 봐도 어떤 기능을 하는지 파악할 수 있는지 (선언적인 코드인지 확인)
